### PR TITLE
[graphite-exporter] Allow setting graphite port and add metric mapping option

### DIFF
--- a/charts/graphite-exporter/Chart.yaml
+++ b/charts/graphite-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphite-exporter
 description: A Prometheus exporter for metrics exported in the Graphite plaintext protocol
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "v0.12.3"
 home: https://github.com/djjudas21/charts/tree/master/charts/graphite-exporter
 icon: https://graphiteapp.org/img/apple-touch-icon-144x144.png

--- a/charts/graphite-exporter/templates/configmap.yaml
+++ b/charts/graphite-exporter/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.graphite.mapping -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "graphite-exporter.fullname" . }}-mapping
+  labels:
+    {{- include "graphite-exporter.labels" . | nindent 4 }}
+data:
+  graphite_mapping.conf: {{ toYaml .Values.graphite.mapping | indent 2 }}
+
+{{- end }}

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/graphite_exporter"]
-          {{- if .Values.graphite.mapping -}}
+          {{- if .Values.graphite.mapping }}
           args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}", "--graphite.mapping-config", "/tmp/graphite_mapping.conf"]
           {{- else }}
           args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}"]

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/graphite_exporter"]
-          args: ["--graphite.listen-address", "{{ .Values.service.graphite.port }}"]
+          args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}"]
           ports:
           ports:
             - name: prometheus

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -50,6 +50,13 @@ spec:
               port: prometheus
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.graphite.mapping }}
+          volumeMounts:
+          - mountPath: /tmp/graphite_mapping.conf
+            name: mapping
+            subPath: graphite_mapping.conf
+            readOnly: true
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -61,4 +68,10 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.graphite.mapping }}
+      volumes:
+      - name: mapping
+        configMap:
+          name: {{ include "graphite-exporter.fullname" . }}-mapping
       {{- end }}

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -32,7 +32,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/graphite_exporter"]
+          {{- if .Values.graphite.mapping -}}
+          args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}", "--graphite.mapping-config", "/tmp/graphite_mapping.conf"]
+          {{- else }}
           args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}"]
+          {{- end }}
           ports:
           ports:
             - name: prometheus

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/graphite_exporter"]
+          args: ["--graphite.listen-address", "{{ .Values.service.graphite.port }}"]
           ports:
           ports:
             - name: prometheus

--- a/charts/graphite-exporter/values.yaml
+++ b/charts/graphite-exporter/values.yaml
@@ -47,6 +47,10 @@ service:
     annotations: {}
     # metallb.universe.tf/allow-shared-ip: graphite-exporter
 
+graphite:
+  mapping: |-
+    # Add custom graphite mappings here: https://github.com/prometheus/graphite_exporter#metric-mapping-and-configuration
+
 # Enable this if you have the Prometheus Operator, to create a ServiceMonitor
 # resource so Prometheus will scrape this endpoint
 serviceMonitor:

--- a/charts/graphite-exporter/values.yaml
+++ b/charts/graphite-exporter/values.yaml
@@ -47,8 +47,8 @@ service:
     annotations: {}
     # metallb.universe.tf/allow-shared-ip: graphite-exporter
 
-graphite:
-  mapping: |-
+graphite: {}
+  #mapping: |-
     # Add custom graphite mappings here: https://github.com/prometheus/graphite_exporter#metric-mapping-and-configuration
 
 # Enable this if you have the Prometheus Operator, to create a ServiceMonitor


### PR DESCRIPTION
Hi,

This PR adds the option to set the graphite listening port. This is needed in some cases (Truenas doesn't allow changing the port in a persistent way when exporting data).

I've also added the option for a configmap containing graphite metric mappings (https://github.com/prometheus/graphite_exporter#metric-mapping-and-configuration).

These changes should only be activated if someone requires them. The port change edits the run command for the container but since port 9109 is the default value in values.yaml this shouldn't be an issue.

Let me know if you want me to change anything! :)

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
