### PR TITLE
[navidrome] Navidrome 0.48.0

### DIFF
--- a/charts/navidrome/Chart.yaml
+++ b/charts/navidrome/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 0.47.5
+appVersion: 0.48.0
 description: Navidrome is an open source web-based music collection server and streamer
 name: navidrome
-version: 6.5.3
+version: 6.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - navidrome
@@ -20,8 +20,8 @@ maintainers:
 dependencies:
   - name: common
     repository: http://bjw-s.github.io/helm-charts/
-    version: 0.1.0
+    version: 0.2.0
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Fix icon URL
+      description: Upgrade to Navidrome v0.48.0

--- a/charts/navidrome/values.yaml
+++ b/charts/navidrome/values.yaml
@@ -40,6 +40,12 @@ ingress:
   # @default -- See values.yaml
   main:
     enabled: false
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        location /metrics {
+          deny all;
+          return 403;
+        }
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml

--- a/charts/navidrome/values.yaml
+++ b/charts/navidrome/values.yaml
@@ -26,6 +26,8 @@ env:
   ND_ENABLETRANSCODINGCONFIG: "true"
   # -- Folder where your music library is stored.
   ND_MUSICFOLDER: /music
+  # -- Enable extra endpoint with Prometheus metrics.
+  ND_PROMETHEUS_ENABLED: "false"
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
@@ -34,6 +36,17 @@ service:
     ports:
       http:
         port: 4533
+    monitor:
+      # -- Enables or disables the serviceMonitor.
+      enabled: false
+      # -- Configures the endpoints for the serviceMonitor.
+      # @default -- See values.yaml
+      endpoints:
+        - port: http
+          scheme: http
+          path: /metrics
+          interval: 1m
+          scrapeTimeout: 10s
 
 ingress:
   # -- Enable and configure ingress settings for the chart under this key.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

* Update Navidrome app to v0.48.0
* Add support for exposing `/metrics` endpoint
* Update bjw-s/common to v0.2.0

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
