### PR TITLE
[smtp-relay] Add metrics

### DIFF
--- a/charts/smtp-relay/Chart.yaml
+++ b/charts/smtp-relay/Chart.yaml
@@ -3,7 +3,7 @@ name: smtp-relay
 description: An SMTP smarthost relay for Kubernetes
 type: application
 version: 0.3.2
-appVersion: "0.5.0"
+appVersion: "0.6.1"
 home: https://github.com/djjudas21/charts/tree/main/charts/smtp-relay
 keywords:
   - smtp

--- a/charts/smtp-relay/Chart.yaml
+++ b/charts/smtp-relay/Chart.yaml
@@ -2,13 +2,14 @@ apiVersion: v2
 name: smtp-relay
 description: An SMTP smarthost relay for Kubernetes
 type: application
-version: 0.3.2
+version: 0.4.0
 appVersion: "0.6.1"
 home: https://github.com/djjudas21/charts/tree/main/charts/smtp-relay
 keywords:
   - smtp
   - relay
   - smarthost
+  - postfix
 maintainers:
   - name: djjudas21
     email: djjudas21@users.noreply.github.com
@@ -18,4 +19,4 @@ sources:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Fix chart URL
+      description: Add support for metrics

--- a/charts/smtp-relay/files/prometheus.rules
+++ b/charts/smtp-relay/files/prometheus.rules
@@ -1,0 +1,8 @@
+    - alert: PostfixRelayDown
+      expr: postfix_up != 1
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: Postfix SMTP relay is down (instance {{ $labels.instance }})
+        description: "A Postfix SMTP relay is down.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/charts/smtp-relay/templates/deployment.yaml
+++ b/charts/smtp-relay/templates/deployment.yaml
@@ -71,10 +71,24 @@ spec:
             - name: smtp
               containerPort: 25
               protocol: TCP
-#          readinessProbe:
-            #httpGet:
-              #path: /
-              #port: smtp
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            tcpSocket:
+              port: 25
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          {{-  end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            tcpSocket:
+              port: 25
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{-  end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/smtp-relay/templates/deployment.yaml
+++ b/charts/smtp-relay/templates/deployment.yaml
@@ -25,12 +25,22 @@ spec:
       serviceAccountName: {{ include "smtp-relay.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: sockets
+        emptyDir: {}
+      - name: log
+        emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+          - name: sockets
+            mountPath: /var/spool/postfix/public
+          - name: log
+            mountPath: /var/log
           env:
             - name: SMTP_RELAY_HOST
               valueFrom:
@@ -91,6 +101,25 @@ spec:
           {{-  end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: chatwork/kumina-postfix-exporter:edge
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--postfix.showq_path", "/var/spool/postfix/public/showq"]
+          ports:
+            - name: metrics
+              containerPort: 9154
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9154
+          volumeMounts:
+          - name: sockets
+            mountPath: /var/spool/postfix/public
+          - name: log
+            mountPath: /var/log
+        {{-  end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/smtp-relay/templates/prometheusrule.yaml
+++ b/charts/smtp-relay/templates/prometheusrule.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: service-prometheus
+    role: alert-rules
+  name: {{ include "smtp-relay.fullname" . }}
+spec:
+  groups:
+  - name: smtp-relay.rules
+    rules:
+{{ .Files.Get "files/prometheus.rules" }}
+{{- end }}

--- a/charts/smtp-relay/templates/service.yaml
+++ b/charts/smtp-relay/templates/service.yaml
@@ -14,5 +14,9 @@ spec:
       targetPort: 25
       protocol: TCP
       name: smtp
+    - port: {{ .Values.metrics.port }}
+      targetPort: 9154
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "smtp-relay.selectorLabels" . | nindent 4 }}

--- a/charts/smtp-relay/templates/servicemonitor.yaml
+++ b/charts/smtp-relay/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "smtp-relay.fullname" . }}
+  labels:
+    {{- include "smtp-relay.labels" . | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "smtp-relay.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 30s
+{{- end }}

--- a/charts/smtp-relay/values.yaml
+++ b/charts/smtp-relay/values.yaml
@@ -94,3 +94,5 @@ metrics:
   port: 9154
   serviceMonitor:
     enabled: false
+  prometheusRules:
+    enabled: false

--- a/charts/smtp-relay/values.yaml
+++ b/charts/smtp-relay/values.yaml
@@ -39,6 +39,20 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+probes:
+  liveness:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+  readiness:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/smtp-relay/values.yaml
+++ b/charts/smtp-relay/values.yaml
@@ -88,3 +88,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+metrics:
+  enabled: false
+  port: 9154
+  serviceMonitor:
+    enabled: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds a metrics sidecar to Postfix based on https://github.com/kumina/postfix_exporter. It also adds integration with the Prometheus operator by adding a serviceMonitor and a prometheusRule.

Default behaviour is retained, i.e. you have to opt in to deploying metrics by setting `metrics.enabled: true`

The version of the Alpine-based Postfix image is also bumped as it had been static for a year.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
