### PR TITLE
[graphite-exporter] remove duplicate `ports:` in deployment.yaml

### DIFF
--- a/charts/graphite-exporter/Chart.yaml
+++ b/charts/graphite-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphite-exporter
 description: A Prometheus exporter for metrics exported in the Graphite plaintext protocol
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "v0.12.3"
 home: https://github.com/djjudas21/charts/tree/master/charts/graphite-exporter
 icon: https://graphiteapp.org/img/apple-touch-icon-144x144.png

--- a/charts/graphite-exporter/templates/deployment.yaml
+++ b/charts/graphite-exporter/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           args: ["--graphite.listen-address", ":{{ .Values.service.graphite.port }}"]
           {{- end }}
           ports:
-          ports:
             - name: prometheus
               containerPort: {{ .Values.service.prometheus.port }}
               protocol: TCP


### PR DESCRIPTION
<!--
Thank you for contributing to djjudas21/charts.
Before you submit this pull request we'd like to make sure you are aware of best practices:

* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Remove duplicate `ports:` in deployment of graphite-exporter
#### Which issue this PR fixes

Fluxv2 can't handle duplicate entries in YAML as per the following issue https://github.com/fluxcd/flux2/issues/1522
Warning  error  3m55s (x44 over 8h)  helm-controller  reconciliation failed: Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 38: mapping key "ports" already defined at line 37

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
