### PR TITLE
[uptime-kuma] Fix for currently broken chart

### DIFF
--- a/charts/uptime-kuma/templates/NOTES.txt
+++ b/charts/uptime-kuma/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- include "common.notes.defaultNotes" . -}}
+{{- include "bjw-s.common.lib.chart.notes" . -}}

--- a/charts/uptime-kuma/templates/common.yaml
+++ b/charts/uptime-kuma/templates/common.yaml
@@ -1,5 +1,5 @@
 {{/* Make sure all variables are set properly */}}
-{{- include "common.values.setup" . }}
+{{- include "bjw-s.common.loader.init" . }}
 
 {{/* Append the hardcoded settings */}}
 {{- define "uptime-kuma.hardcodedValues" -}}
@@ -9,4 +9,4 @@ env:
     {{- $_ := mergeOverwrite .Values (include "uptime-kuma.hardcodedValues" . | fromYaml) -}}
 
     {{/* Render the templates */}}
-{{ include "common.all" . }}
+{{ include "bjw-s.common.loader.generate" . }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

As reported in usse #43, the uptime-kuma chart is currently broken. Not going to bump the chart version as the current one could not have been in use anyway.

#### Which issue this PR fixes

- fixes #43

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
