### PR TITLE
Workflow command "set-output" was deprecated

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .github/linters/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "name=changed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: install helm unittest plugin


### PR DESCRIPTION
Workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions