### PR TITLE
[smtp-relay] SMTP relay persistence

### DIFF
--- a/charts/smtp-relay/Chart.yaml
+++ b/charts/smtp-relay/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smtp-relay
 description: An SMTP smarthost relay for Kubernetes
 type: application
-version: 0.4.0
-appVersion: "0.6.1"
+version: 0.5.0
+appVersion: "0.7.0"
 home: https://github.com/djjudas21/charts/tree/main/charts/smtp-relay
 keywords:
   - smtp
@@ -19,4 +19,4 @@ sources:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Add support for metrics
+      description: Add support for persistence

--- a/charts/smtp-relay/README.md
+++ b/charts/smtp-relay/README.md
@@ -1,4 +1,5 @@
 # smtp-relay
+
 Helm chart for smtp-relay
 
 This image provides an SMTP relay host for emails from within a Kubernetes cluster.
@@ -6,7 +7,7 @@ This image provides an SMTP relay host for emails from within a Kubernetes clust
 Configure this container to use an upstream authenticated SMTP relay like SendGrid or your ISP's mail server, and provide an
 open relay service to your cluster. This means you don't have to configure all of your containerised services with email auth secrets.
 
-```
+```sh
 helm repo add djjudas21 https://djjudas21.github.io/charts/
 helm repo update
 helm upgrade --install -n smtp-relay  [-f values.yaml] --create-namespace djjudas21/smtp-relay

--- a/charts/smtp-relay/README.md
+++ b/charts/smtp-relay/README.md
@@ -21,3 +21,44 @@ As a minimum, you will need to provide your own `values.yaml` with some SMTP con
 | `smtp.password`   | Required | Password for SMTP server to relay to | `pAsSwOrD`                      |
 | `smtp.myhostname` | Optional | Hostname of this relay SMTP server   | `smtp-relay.example.com         |
 | `smtp.mynetworks` | Optional | Networks to permit relaying from     | `['127.0.0.0/8', '10.0.0.0/8']` |
+
+## Persistence
+
+By default, this chart sets up an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume to contain the
+Postfix spool directory (`/var/spool/postfix`). If the pod crashes or gets restarted while there are still unsent messages in the
+queue, those messages will be lost, as the emptyDir has the same lifetime as the pod.
+
+You can enable persistence which creates a small [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+to contain `/var/spool/postfix` which will survive pod restarts. If you have multiple replicas, each replica will have its own
+spool volume to represent its own mail queue.
+
+Example configuration:
+
+```yaml
+persistence:
+  enabled: true
+  accessMode: "ReadWriteOnce"
+  size: 1Gi
+  storageClass: ""
+```
+
+## Metrics
+
+If the metrics sidecar is enabled, both the Postfix container and the metrics container additionally mount another subdir
+`/var/spool/postfix/public` as an emptyDir. This directory contains some Postfix sockets, and allows both containers in
+the same pod to have access to the same sockets, so the metrics container can report on your Postfix `mailq`.
+
+Sockets do not work properly in persistent volumes, so this is why an emptyDir is mounted inside a persistent volume.
+You shouldn't need to worry about this unless you are a chart maintainer!
+
+Example configuration:
+
+```yaml
+metrics:
+  enabled: true
+  port: 9154
+  serviceMonitor:
+    enabled: false
+  prometheusRules:
+    enabled: false
+```

--- a/charts/smtp-relay/templates/statefulset.yaml
+++ b/charts/smtp-relay/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "smtp-relay.labels" . | nindent 4 }}
 spec:
-replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "smtp-relay.selectorLabels" . | nindent 6 }}

--- a/charts/smtp-relay/templates/statefulset.yaml
+++ b/charts/smtp-relay/templates/statefulset.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "smtp-relay.fullname" . }}
   labels:
     {{- include "smtp-relay.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "smtp-relay.selectorLabels" . | nindent 6 }}
@@ -37,6 +37,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
+          {{- if .Values.persistence.enabled }}  
+          - name: spool
+            mountPath: /var/spool/postfix
+          {{- end }}
           - name: sockets
             mountPath: /var/spool/postfix/public
           - name: log
@@ -115,6 +119,10 @@ spec:
               path: /metrics
               port: 9154
           volumeMounts:
+          {{- if .Values.persistence.enabled }}  
+          - name: spool
+            mountPath: /var/spool/postfix
+          {{- end }}
           - name: sockets
             mountPath: /var/spool/postfix/public
           - name: log
@@ -132,3 +140,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.persistence.enabled }}  
+  volumeClaimTemplates:
+  - metadata:
+      name: spool
+    spec:
+      accessModes: 
+      - {{ .Values.persistence.accessMode }}
+      storageClassName: {{ .Values.persistence.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/charts/smtp-relay/values.yaml
+++ b/charts/smtp-relay/values.yaml
@@ -83,6 +83,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+persistence:
+  # server.persistence.enabled is the toggle for server volume persistence.
+  enabled: false
+  accessMode: "ReadWriteOnce"
+  # The storage space that should be claimed from the persistent volume
+  size: 1Gi
+  # If undefined (the default) the default StorageClass is used
+  storageClass: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds support to create persistent volumes for Postfix SMTP relay, so queued messages aren't lost if the pod restarts

Also added better documentation in the README

#### Which issue this PR fixes

- fixes #61

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
