### PR TITLE
uptime-kuma: Update to 1.23.12.

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 1.23.11
+appVersion: 1.23.12
 description: A fancy self-hosted monitoring tool for your websites and applications
 name: uptime-kuma
-version: 1.5.12
+version: 1.5.13
 kubeVersion: ">=1.16.0-0"
 keywords:
   - uptime-kuma
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update to Uptime Kuma 1.23.11
+      description: Update to Uptime Kuma 1.23.12


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Update `uptime-kuma` chart.

This also fixes the chart, since there is no `1.23.11` tag on Docker Hub, but there is one for `1.23.12`. I just noticed my Helm release has been failing with `ImagePullBackOff` for a while now due to this.

#### Which issue this PR fixes


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
