### PR TITLE
lldap-external-database

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/templates/_helpers.tpl
+++ b/charts/lldap/templates/_helpers.tpl
@@ -65,8 +65,14 @@ Create the name of the service account to use
 Build database connection strings as templates
 */}}
 {{- define "lldap.postgresConnectString" -}}
-postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "lldap.fullname" . }}-postgresql/{{ .Values.postgresql.auth.database }}
+postgres://{{- .Values.postgresql.auth.username -}}:{{- .Values.postgresql.auth.password -}}@{{- include "lldap.fullname" . -}}-postgresql/{{- .Values.postgresql.auth.database -}}
+{{- end }}
+{{- define "lldap.externalPostgresConnectString" -}}
+postgres://{{- .Values.externalPostgresql.auth.username -}}:{{- .Values.externalPostgresql.auth.password -}}@{{- .Values.externalPostgresql.auth.host -}}:{{- .Values.externalPostgresql.auth.port -}}/{{- .Values.externalPostgresql.auth.database -}}
 {{- end }}
 {{- define "lldap.mariadbConnectString" -}}
-mysql://{{ .Values.mariadb.auth.username }}:{{ .Values.mariadb.auth.password }}@{{ include "lldap.fullname" . }}-mariadb/{{ .Values.mariadb.auth.database }}
+mysql://{{- .Values.mariadb.auth.username -}}:{{- .Values.mariadb.auth.password -}}@{{- include "lldap.fullname" . -}}-mariadb/{{- .Values.mariadb.auth.database -}}
+{{- end }}
+{{- define "lldap.externalMariadbConnectString" -}}
+mysql://{{- .Values.externalMariadb.auth.username -}}:{{- .Values.externalMariadb.auth.password -}}@{{- .Values.externalMariadb.auth.host -}}:{{- .Values.externalMariadb.auth.port -}}/{{- .Values.externalMariadb.auth.database -}}
 {{- end }}

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: LLDAP_DATABASE_URL
             {{- if .Values.postgresql.enabled }}
               value: {{ include "lldap.postgresConnectString" . | quote }}
-            {{- if .Values.eternalPostgresql.enabled }}
+            {{- else if .Values.externalPostgresql.enabled }}
               value: {{ include "lldap.externalPostgresConnectString" . | quote }}
             {{- else if .Values.mariadb.enabled }}
               value: {{ include "lldap.mariadbConnectString" . | quote }}

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -64,8 +64,12 @@ spec:
             - name: LLDAP_DATABASE_URL
             {{- if .Values.postgresql.enabled }}
               value: {{ include "lldap.postgresConnectString" . | quote }}
+            {{- if .Values.eternalPostgresql.enabled }}
+              value: {{ include "lldap.externalPostgresConnectString" . | quote }}
             {{- else if .Values.mariadb.enabled }}
               value: {{ include "lldap.mariadbConnectString" . | quote }}
+            {{- else if .Values.externalMariadb.enabled }}
+              value: {{ include "lldap.externalMariadbConnectString" . | quote }}
             {{- else }}
               value: "sqlite:///data/users.db?mode=rwc"
             {{- end }}

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -205,6 +205,18 @@ postgresql:
       size: 1Gi
     resources: {}
 
+
+# --- Enable and configure external postgresql database
+externalPostgresql:
+  enabled: false
+  auth:
+    host: ""
+    port: 5432
+    username:	""
+    password:	""
+    database: lldap
+
+
 # -- Enable and configure mariadb database subchart under this key.
 #    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
 # @default -- https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
@@ -222,6 +234,18 @@ mariadb:
       enabled: false
       size: 1Gi
       # storageClass: ""
+
+
+# -- Enable and configure external mariadb database
+externalMariadb:
+  enabled: false
+  auth:
+    host: ""
+    port: 3306
+    username: ""
+    password: ""
+    database: lldap
+
 
 # -- Bootstrap (i.e. create) users and groups automatically.
 # It is safe to run the bootstrap multiple times, however the one-shot


### PR DESCRIPTION
#### What this PR does / why we need it

Allows to use external Postgresql or MariDB instance without using the subchart.

#### Which issue this PR fixes

- fixes #78

#### Special notes for your reviewer

Does not contains any breaking changes, it extends the values only

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
