### PR TITLE
lldap-extra-volume-mounts

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -128,17 +128,23 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if $.Values.persistence.enabled }}
           volumeMounts:
+            {{- with .Values.lldap.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if $.Values.persistence.enabled }}
             - mountPath: /data
               name: {{ include "lldap.fullname" . }}-data
-          {{- end }}
-      {{- if $.Values.persistence.enabled }}
+            {{- end }}
       volumes:
+        {{- with .Values.lldap.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.persistence.enabled }}
         - name: {{ include "lldap.fullname" . }}-data
           persistentVolumeClaim:
             claimName: {{ include "lldap.fullname" . }}-data
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -87,6 +87,10 @@ lldap:
     # -- Certificate key file.
     keyFile: "/data/key.pem"
 
+  # --- define extra volumes and mounts for the ldap
+  extraVolumes: []
+  extraVolumeMounts: []
+
   # -- Ignored attributes.
   # Some services will request attributes that are not present in LLDAP. When it is the case, LLDAP
   # will warn about the attribute being unknown. If you want to ignore the attribute and the
@@ -154,7 +158,7 @@ ingress:
 # You can disable persistence if you select MariaDB or PostgreSQL.
 # @default -- see below
 persistence:
-  enabled: false
+  enabled: true
   size: 100Mi
   accessMode: ReadWriteOnce
   ## If defined, storageClassName: <storageClass>

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -158,7 +158,7 @@ ingress:
 # You can disable persistence if you select MariaDB or PostgreSQL.
 # @default -- see below
 persistence:
-  enabled: true
+  enabled: false
   size: 100Mi
   accessMode: ReadWriteOnce
   ## If defined, storageClassName: <storageClass>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The PR extends on the LLDAP chart the possibility to add extra volumes and mounts e.g. for secret

#### Which issue this PR fixes

- fixes #81

#### Special notes for your reviewer

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
