### PR TITLE
Tag should be a string

### DIFF
--- a/charts/homer/Chart.yaml
+++ b/charts/homer/Chart.yaml
@@ -5,7 +5,7 @@ description: A dead simple static HOMepage for your servER to keep your services
 icon: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/logo.png
 home: https://github.com/djjudas21/charts/tree/master/charts/homer
 name: homer
-version: 8.1.14
+version: 8.1.15
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/bastienwirtz/homer

--- a/charts/homer/README.md
+++ b/charts/homer/README.md
@@ -1,6 +1,6 @@
 # homer
 
-![Version: 8.1.14](https://img.shields.io/badge/Version-8.1.14-informational?style=flat-square) ![AppVersion: v23.10.1](https://img.shields.io/badge/AppVersion-v23.10.1-informational?style=flat-square)
+![Version: 8.1.15](https://img.shields.io/badge/Version-8.1.15-informational?style=flat-square) ![AppVersion: v23.10.1](https://img.shields.io/badge/AppVersion-v23.10.1-informational?style=flat-square)
 
 A dead simple static HOMepage for your servER to keep your services on hand, from a simple yaml configuration file.
 

--- a/charts/homer/values.schema.json
+++ b/charts/homer/values.schema.json
@@ -78,7 +78,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/homer/values.yaml
+++ b/charts/homer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: b4bz/homer
   # -- image tag
   # @default -- chart.appVersion
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/joplin-server/Chart.yaml
+++ b/charts/joplin-server/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.14.2-beta
 description: This server allows you to sync any Joplin client
 name: joplin-server
-version: 5.5.4
+version: 5.5.5
 keywords:
   - joplin
   - notes

--- a/charts/joplin-server/README.md
+++ b/charts/joplin-server/README.md
@@ -1,6 +1,6 @@
 # joplin-server
 
-![Version: 5.5.4](https://img.shields.io/badge/Version-5.5.4-informational?style=flat-square) ![AppVersion: 2.14.2-beta](https://img.shields.io/badge/AppVersion-2.14.2--beta-informational?style=flat-square)
+![Version: 5.5.5](https://img.shields.io/badge/Version-5.5.5-informational?style=flat-square) ![AppVersion: 2.14.2-beta](https://img.shields.io/badge/AppVersion-2.14.2--beta-informational?style=flat-square)
 
 This server allows you to sync any Joplin client
 

--- a/charts/joplin-server/values.schema.json
+++ b/charts/joplin-server/values.schema.json
@@ -99,7 +99,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/joplin-server/values.yaml
+++ b/charts/joplin-server/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: joplin/server
   # -- image tag
   # @default -- chart.appVersion
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/navidrome/Chart.yaml
+++ b/charts/navidrome/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 0.53.2
 description: Navidrome is an open source web-based music collection server and streamer
 name: navidrome
-version: 6.6.15
+version: 6.6.16
 kubeVersion: ">=1.16.0-0"
 keywords:
   - navidrome

--- a/charts/navidrome/README.md
+++ b/charts/navidrome/README.md
@@ -1,6 +1,6 @@
 # navidrome
 
-![Version: 6.6.15](https://img.shields.io/badge/Version-6.6.15-informational?style=flat-square) ![AppVersion: 0.53.2](https://img.shields.io/badge/AppVersion-0.53.2-informational?style=flat-square)
+![Version: 6.6.16](https://img.shields.io/badge/Version-6.6.16-informational?style=flat-square) ![AppVersion: 0.53.2](https://img.shields.io/badge/AppVersion-0.53.2-informational?style=flat-square)
 
 Navidrome is an open source web-based music collection server and streamer
 

--- a/charts/navidrome/README.md
+++ b/charts/navidrome/README.md
@@ -39,7 +39,7 @@ Kubernetes: `>=1.16.0-0`
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"deluan/navidrome"` | image repository |
-| image.tag | string | `nil` | image tag |
+| image.tag | string | `""` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |

--- a/charts/navidrome/values.schema.json
+++ b/charts/navidrome/values.schema.json
@@ -85,7 +85,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/navidrome/values.yaml
+++ b/charts/navidrome/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- image repository
   repository: deluan/navidrome
   # -- image tag
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/photoprism/Chart.yaml
+++ b/charts/photoprism/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 240711-ce
 description: PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 name: photoprism
-version: 7.4.17
+version: 7.4.18
 kubeVersion: ">=1.16.0-0"
 keywords:
   - photos

--- a/charts/photoprism/README.md
+++ b/charts/photoprism/README.md
@@ -1,6 +1,6 @@
 # photoprism
 
-![Version: 7.4.17](https://img.shields.io/badge/Version-7.4.17-informational?style=flat-square) ![AppVersion: 240711-ce](https://img.shields.io/badge/AppVersion-240711--ce-informational?style=flat-square)
+![Version: 7.4.18](https://img.shields.io/badge/Version-7.4.18-informational?style=flat-square) ![AppVersion: 240711-ce](https://img.shields.io/badge/AppVersion-240711--ce-informational?style=flat-square)
 
 PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 

--- a/charts/photoprism/values.schema.json
+++ b/charts/photoprism/values.schema.json
@@ -127,7 +127,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/photoprism/values.yaml
+++ b/charts/photoprism/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: photoprism/photoprism
   # -- image tag
   # @default -- chart.appVersion
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 1.23.12
 description: A fancy self-hosted monitoring tool for your websites and applications
 name: uptime-kuma
-version: 1.5.15
+version: 1.5.16
 kubeVersion: ">=1.16.0-0"
 keywords:
   - uptime-kuma

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 1.5.15](https://img.shields.io/badge/Version-1.5.15-informational?style=flat-square) ![AppVersion: 1.23.12](https://img.shields.io/badge/AppVersion-1.23.12-informational?style=flat-square)
+![Version: 1.5.16](https://img.shields.io/badge/Version-1.5.16-informational?style=flat-square) ![AppVersion: 1.23.12](https://img.shields.io/badge/AppVersion-1.23.12-informational?style=flat-square)
 
 A fancy self-hosted monitoring tool for your websites and applications
 

--- a/charts/uptime-kuma/values.schema.json
+++ b/charts/uptime-kuma/values.schema.json
@@ -50,7 +50,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: louislam/uptime-kuma
   # -- image tag
   # @default -- chart.appVersion
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/webtrees/Chart.yaml
+++ b/charts/webtrees/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.1.20
 description: Open-source online collaborative genealogy application
 name: webtrees
-version: 2.2.14
+version: 2.2.15
 kubeVersion: ">=1.16.0-0"
 keywords:
   - webtrees

--- a/charts/webtrees/README.md
+++ b/charts/webtrees/README.md
@@ -1,6 +1,6 @@
 # webtrees
 
-![Version: 2.2.14](https://img.shields.io/badge/Version-2.2.14-informational?style=flat-square) ![AppVersion: 2.1.20](https://img.shields.io/badge/AppVersion-2.1.20-informational?style=flat-square)
+![Version: 2.2.15](https://img.shields.io/badge/Version-2.2.15-informational?style=flat-square) ![AppVersion: 2.1.20](https://img.shields.io/badge/AppVersion-2.1.20-informational?style=flat-square)
 
 Open-source online collaborative genealogy application
 

--- a/charts/webtrees/values.schema.json
+++ b/charts/webtrees/values.schema.json
@@ -141,7 +141,7 @@
           "description": "image tag",
           "required": [],
           "title": "tag",
-          "type": "null"
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/webtrees/values.yaml
+++ b/charts/webtrees/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/nathanvaughn/webtrees
   # -- image tag
   # @default -- chart.appVersion
-  tag:
+  tag: ""
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Handle `image.tag` as a string in the Helm schema, so it can be overridden. This is fixed for Homer as originally reported, and several other charts that had the same bug.

Fixes #96 