### PR TITLE
lldap: Add ability to add annotations to deployment

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -124,11 +124,11 @@ spec:
             - name: ldap
               containerPort: {{ .Values.service.ldap.port }}
               protocol: TCP
-            {{ if $.Values.lldap.ldaps.enabled }}
+            {{- if $.Values.lldap.ldaps.enabled }}
             - name: ldaps
               containerPort: {{ .Values.service.ldaps.port }}
               protocol: TCP
-            {{ end }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "lldap.fullname" . }}
   labels:
     {{- include "lldap.labels" . | nindent 4 }}
+  {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -18,7 +18,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 lldap:
-
   # -- Base DN for LDAP.
   # This is usually your domain name, and is used as a namespace for your users. The choice is
   # arbitrary, but will be needed to configure the LDAP integration with other services. The sample
@@ -111,6 +110,8 @@ serviceAccount:
 
 podAnnotations: {}
 podLabels: {}
+deploymentAnnotations: {}
+deploymentLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
#### What this PR does / why we need it

This PR allows the ability to add extra deployment labels and annotations through value files.

It's required to allow systems such as `Reloader`  https://github.com/stakater/Reloader 

This will allow the ability to reload the server when a TLS Secret/Certificate is refreshed.

#### Which issue this PR fixes

I didn't create a incident.


#### Checklist

- [ X] Chart Version bumped
- [X ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
