### PR TITLE
Fix LLDAP bootstrap image tag

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -45,4 +45,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update to lldap v0.6.1
+      description: Fix bootstrap image tag

--- a/charts/lldap/templates/bootstrap-job.yaml
+++ b/charts/lldap/templates/bootstrap-job.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: bootstrap
-          image: "{{ .Values.image.repository }}:2024-04-01"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
             - ./bootstrap.sh
           env:


### PR DESCRIPTION
Replace static image tag for the bootstrap job with dynamic image tag used for the main deployment.

Fixes #125 