### PR TITLE
[lldap] Fix lldap UID/GID

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -42,9 +42,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: uid
+            - name: UID
               value: "{{ .Values.lldap.uid }}"
-            - name: gid
+            - name: GID
               value: "{{ .Values.lldap.gid }}"
             - name: TZ
               value: "{{ .Values.lldap.tz }}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

template use uid/gid for env var but UID/GID needed. lldap docker-entrypoint.sh use UID/GID for chown and gosu.

#### Which issue this PR fixes

- fixes #131 

#### Special notes for your reviewer

i am new for helm, please say any errors and i will fix

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
