### PR TITLE
[lldap] allow specifying app and database credentials as external secrets

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/templates/_helpers.tpl
+++ b/charts/lldap/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the credentials secret
+*/}}
+{{- define "lldap.credentialsSecretName" -}}
+{{ .Values.lldap.secretName | default (printf "%s-credentials" (include "lldap.fullname" .)) }}
+{{- end }}
+
+{{/*
 Build database connection strings as templates
 */}}
 {{- define "lldap.postgresConnectString" -}}

--- a/charts/lldap/templates/bootstrap-job.yaml
+++ b/charts/lldap/templates/bootstrap-job.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "lldap.fullname" . }}-bootstrap
   # Next annotations are required if the job managed by Argo CD,
   # so Argo CD can relaunch the job on every app sync action
-  annotations: 
+  annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
@@ -23,9 +23,9 @@ spec:
             - name: LLDAP_ADMIN_USERNAME
               value: "{{ .Values.lldap.ldapUserDN }}"
             - name: LLDAP_ADMIN_PASSWORD
-              valueFrom: 
-                secretKeyRef: 
-                  name: {{ include "lldap.fullname" . }}-credentials
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lldap.credentialsSecretName" . }}
                   key: ldapUserPass
             - name: DO_CLEANUP
               value: "{{ .Values.bootstrap.cleanup }}"

--- a/charts/lldap/templates/bootstrap-job.yaml
+++ b/charts/lldap/templates/bootstrap-job.yaml
@@ -26,7 +26,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
-                  key: ldapUserPass
+                  key: {{ .Values.lldap.ldapUserPassKey }}
             - name: DO_CLEANUP
               value: "{{ .Values.bootstrap.cleanup }}"
           volumeMounts:

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -71,10 +71,20 @@ spec:
             - name: LLDAP_DATABASE_URL
             {{- if .Values.postgresql.enabled }}
               value: {{ include "lldap.postgresConnectString" . | quote }}
+            {{- else if and .Values.externalPostgresql.enabled .Values.externalPostgresql.fromSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalPostgresql.fromSecret }}
+                  key: {{ .Values.externalPostgresql.uriKey }}
             {{- else if .Values.externalPostgresql.enabled }}
               value: {{ include "lldap.externalPostgresConnectString" . | quote }}
             {{- else if .Values.mariadb.enabled }}
               value: {{ include "lldap.mariadbConnectString" . | quote }}
+            {{- else if and .Values.externalMariadb.enabled .Values.externalMariadb.fromSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalMariadb.fromSecret }}
+                  key: {{ .Values.externalMariadb.uriKey }}
             {{- else if .Values.externalMariadb.enabled }}
               value: {{ include "lldap.externalMariadbConnectString" . | quote }}
             {{- else }}

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
-                  value: {{ .Values.lldap.keySeedKey }}
+                  key: {{ .Values.lldap.keySeedKey }}
               value: "{{ .Values.lldap.keySeed }}"
             {{- if $.Values.lldap.smtp.enablePasswordReset }}
             - name: LLDAP_SMTP_OPTIONS__ENABLE_PASSWORD_RESET

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -59,14 +59,14 @@ spec:
             - name: LLDAP_HTTP_PORT
               value: "{{ .Values.service.http.port }}"
             - name: LLDAP_JWT_SECRET
-              valueFrom: 
-                secretKeyRef: 
-                  name: {{ include "lldap.fullname" . }}-credentials
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lldap.credentialsSecretName" . }}
                   key: jwtSecret
             - name: LLDAP_LDAP_USER_PASS
-              valueFrom: 
-                secretKeyRef: 
-                  name: {{ include "lldap.fullname" . }}-credentials
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lldap.credentialsSecretName" . }}
                   key: ldapUserPass
             - name: LLDAP_DATABASE_URL
             {{- if .Values.postgresql.enabled }}
@@ -104,9 +104,9 @@ spec:
             - name: LLDAP_SMTP_OPTIONS__REPLY_TO
               value: "{{ .Values.lldap.smtp.replyTo }}"
             - name: LLDAP_SMTP_OPTIONS__PASSWORD
-              valueFrom: 
-                secretKeyRef: 
-                  name: {{ include "lldap.fullname" . }}-credentials
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lldap.credentialsSecretName" . }}
                   key: smtpPassword
             {{- end }}
             {{- if $.Values.lldap.ldaps.enabled }}

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -62,12 +62,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
-                  key: jwtSecret
+                  key: {{ .Values.lldap.jwtSecretKey }}
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
-                  key: ldapUserPass
+                  key: {{ .Values.lldap.ldapUserPassKey }}
             - name: LLDAP_DATABASE_URL
             {{- if .Values.postgresql.enabled }}
               value: {{ include "lldap.postgresConnectString" . | quote }}
@@ -121,7 +121,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
-                  key: smtpPassword
+                  key: {{ .Values.lldap.smtp.passwordKey }}
             {{- end }}
             {{- if $.Values.lldap.ldaps.enabled }}
             - name: LLDAP_LDAPS_OPTIONS__ENABLED

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -101,7 +101,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "lldap.credentialsSecretName" . }}
                   key: {{ .Values.lldap.keySeedKey }}
-              value: "{{ .Values.lldap.keySeed }}"
             {{- if $.Values.lldap.smtp.enablePasswordReset }}
             - name: LLDAP_SMTP_OPTIONS__ENABLE_PASSWORD_RESET
               value: "{{ .Values.lldap.smtp.enablePasswordReset }}"

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             - name: LLDAP_VERBOSE
               value: "{{ .Values.lldap.verbose }}"
             - name: LLDAP_KEY_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lldap.credentialsSecretName" . }}
+                  value: {{ .Values.lldap.keySeedKey }}
               value: "{{ .Values.lldap.keySeed }}"
             {{- if $.Values.lldap.smtp.enablePasswordReset }}
             - name: LLDAP_SMTP_OPTIONS__ENABLE_PASSWORD_RESET

--- a/charts/lldap/templates/secret.yaml
+++ b/charts/lldap/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{ if not .Values.lldap.secretName }}
 kind: Secret
 apiVersion: v1
 type: Opaque
 metadata:
   name: {{ include "lldap.fullname" . }}-credentials
 data:
-  jwtSecret: {{ .Values.lldap.jwtSecret | b64enc }}
-  ldapUserPass: {{ .Values.lldap.ldapUserPass | b64enc }}
-  smtpPassword: {{ .Values.lldap.smtp.password | b64enc }}
+  {{ .Values.lldap.jwtSecretKey }}: {{ .Values.lldap.jwtSecret | b64enc }}
+  {{ .Values.lldap.ldapUserPassKey }}: {{ .Values.lldap.ldapUserPass | b64enc }}
+  {{ .Values.lldap.smtp.passwordKey }}: {{ .Values.lldap.smtp.password | b64enc }}
+{{ end }}

--- a/charts/lldap/templates/secret.yaml
+++ b/charts/lldap/templates/secret.yaml
@@ -8,4 +8,5 @@ data:
   {{ .Values.lldap.jwtSecretKey }}: {{ .Values.lldap.jwtSecret | b64enc }}
   {{ .Values.lldap.ldapUserPassKey }}: {{ .Values.lldap.ldapUserPass | b64enc }}
   {{ .Values.lldap.smtp.passwordKey }}: {{ .Values.lldap.smtp.password | b64enc }}
+  {{ .Values.lldap.keySeedKey }}: {{ .Values.lldap.keySeedKey | b64enc }}
 {{ end }}

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -491,6 +491,13 @@
           "title": "keySeed",
           "type": "string"
         },
+        "keySeedKey": {
+          "default": "keySeed",
+          "description": "Name of the key containing the private key seed in the credentials secret",
+          "required": [],
+          "title": "keySeedKey",
+          "type": "string"
+        },
         "ldapUserDN": {
           "default": "admin",
           "description": "Admin username.\nFor the LDAP interface, a value of \"admin\" here will create the LDAP user\n\"cn=admin,ou=people,dc=example,dc=com\" (with the base DN above). For the administration\ninterface, this is the username.",

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -188,6 +188,20 @@
           "required": [],
           "title": "enabled",
           "type": "boolean"
+        },
+        "fromSecret": {
+          "default": null,
+          "description": "Name of the secret containing the database URI",
+          "required": [],
+          "title": "fromSecret",
+          "type": "string"
+        },
+        "uriKey": {
+          "default": null,
+          "description": "Name of the secret key containing the database URI",
+          "required": [],
+          "title": "uriKey",
+          "type": "string"
         }
       },
       "required": [],
@@ -239,6 +253,20 @@
           "required": [],
           "title": "enabled",
           "type": "boolean"
+        },
+        "fromSecret": {
+          "default": null,
+          "description": "Name of the secret containing the database URI",
+          "required": [],
+          "title": "fromSecret",
+          "type": "string"
+        },
+        "uriKey": {
+          "default": null,
+          "description": "Name of the secret key containing the database URI",
+          "required": [],
+          "title": "uriKey",
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -435,11 +435,25 @@
           "title": "gid",
           "type": "integer"
         },
+        "secretName": {
+          "default": null,
+          "description": "Name of Kubernetes secret containing credentials",
+          "required": [],
+          "title": "secretName",
+          "type": "string"
+        },
         "jwtSecret": {
           "default": "REPLACE_WITH_RANDOM",
           "description": "Random secret for JWT signature.\nThis secret should be random, and should be shared with application servers that need to\nconsume the JWTs. Changing this secret will invalidate all user sessions and require them\nto re-login. You can generate it with (on linux):\nLC_ALL=C tr -dc 'A-Za-z0-9!#%\u0026'\\''()*+,-./:;\u003c=\u003e?@[\\]^_{|}~' \u003c/dev/urandom | head -c 32; echo ''",
           "required": [],
           "title": "jwtSecret",
+          "type": "string"
+        },
+        "jwtSecretKey": {
+          "default": "jwtSecret",
+          "description": "Name of the JWT signature key in the credentials secret",
+          "required": [],
+          "title": "jwtSecretKey",
           "type": "string"
         },
         "keySeed": {
@@ -461,6 +475,13 @@
           "description": "Admin password.\nPassword for the admin account, both for the LDAP bind and for the administration interface.\nIt is only used when initially creating the admin user. It should be minimum 8 characters long.\nNote: you can create another admin user for user administration, this is just the default one.",
           "required": [],
           "title": "ldapUserPass",
+          "type": "string"
+        },
+        "ldapUserPassKey": {
+          "default": "ldapUserPass",
+          "description": "Name of the LDAP admin password key in the credentials secret",
+          "required": [],
+          "title": "ldapUserPassKey",
           "type": "string"
         },
         "ldaps": {
@@ -514,6 +535,13 @@
               "description": "The SMTP password.",
               "required": [],
               "title": "password",
+              "type": "string"
+            },
+            "passwordKey": {
+              "default": "password",
+              "description": "Name of the SMTP password in the credentials secret",
+              "required": [],
+              "title": "passwordKey",
               "type": "string"
             },
             "port": {

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -25,12 +25,21 @@ lldap:
   # actually need to own the domain name.
   baseDN: "dc=example,dc=com"
 
+  # -- Name of the Kubernetes secret containing credentials.
+  # If this isn't specified, a secret will be generated with the credentials provided
+  # in the values file. If you want to provide an external secret, for instance when
+  # deploying with GitOps, specify its name here.
+  secretName: ~
+
   # -- Random secret for JWT signature.
   # This secret should be random, and should be shared with application servers that need to
   # consume the JWTs. Changing this secret will invalidate all user sessions and require them
   # to re-login. You can generate it with (on linux):
   # LC_ALL=C tr -dc 'A-Za-z0-9!#%&'\''()*+,-./:;<=>?@[\]^_{|}~' </dev/urandom | head -c 32; echo ''
   jwtSecret: REPLACE_WITH_RANDOM
+
+  # -- Name of the JWT signature key in the `.Values.lldap.secretName` Kubernetes secret.
+  jwtSecretKey: jwtSecret
 
   # -- Admin username.
   # For the LDAP interface, a value of "admin" here will create the LDAP user
@@ -43,6 +52,9 @@ lldap:
   # It is only used when initially creating the admin user. It should be minimum 8 characters long.
   # Note: you can create another admin user for user administration, this is just the default one.
   ldapUserPass: REPLACE_WITH_RANDOM
+
+  # -- Name of the LDAP admin password key in the `.Values.lldap.secretName` Kubernetes secret.
+  ldapUserPassKey: ldapUserPass
 
   # -- Seed to generate the server private key. This can be any random string, the recommendation
   # is that it's at least 12 characters long.
@@ -70,6 +82,9 @@ lldap:
     user: "sender@gmail.com"
     # -- The SMTP password.
     password: "password"
+    # -- Name of the SMTP password key in the `.Values.lldap.secretName` Kubernetes secret.
+    # Overrides the `.Values.lldap.smtp.password` if a custom secret is defined.
+    passwordKey: password
     # -- The header field: how the sender appears in the email. The first
     # is a free-form name, followed by an email between <>. Optional.
     from: "LLDAP Admin <sender@gmail.com>"

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -87,7 +87,7 @@ lldap:
     password: "password"
     # -- Name of the SMTP password key in the `.Values.lldap.secretName` Kubernetes secret.
     # Overrides the `.Values.lldap.smtp.password` if a custom secret is defined.
-    passwordKey: password
+    passwordKey: smtpPassword
     # -- The header field: how the sender appears in the email. The first
     # is a free-form name, followed by an email between <>. Optional.
     from: "LLDAP Admin <sender@gmail.com>"

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -60,6 +60,9 @@ lldap:
   # is that it's at least 12 characters long.
   keySeed: REPLACE_WITH_RANDOM
 
+  # -- Name of the key holding the private key seed in the `.Values.lldap.secretName` Kubernetes secret.
+  keySeedKey: keySeed
+
   uid: 1000
   gid: 1000
   tz: "Etc/UTC"

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -229,6 +229,10 @@ postgresql:
 # --- Enable and configure external postgresql database
 externalPostgresql:
   enabled: false
+  # -- Name of the Kubernetes secret containing the database URI
+  # fromSecret:
+  # -- Name of the secret key containing the database URI
+  # uriKey:
   auth:
     host: ""
     port: 5432
@@ -259,6 +263,10 @@ mariadb:
 # -- Enable and configure external mariadb database
 externalMariadb:
   enabled: false
+  # -- Name of the Kubernetes secret containing the database URI
+  # fromSecret:
+  # -- Name of the secret key containing the database URI
+  # uriKey:
   auth:
     host: ""
     port: 3306


### PR DESCRIPTION
<!--
Thank you for contributing to djjudas21/charts.
Before you submit this pull request we'd like to make sure you are aware of best practices:

* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR makes it possible to specify the JWT secret, LDAP admin password, SMTP password, and database credentials using an already existing secret, so that the credentials don't need to be stored inside the values file.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
