### PR TITLE
[lldap] Fix secretName

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -29,7 +29,8 @@ lldap:
   # If this isn't specified, a secret will be generated with the credentials provided
   # in the values file. If you want to provide an external secret, for instance when
   # deploying with GitOps, specify its name here.
-  secretName: ~
+  secretName: ""
+
 
   # -- Random secret for JWT signature.
   # This secret should be random, and should be shared with application servers that need to


### PR DESCRIPTION
#### What this PR does / why we need it

Helm upgrade fails as it expects a string for secretName.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
