### PR TITLE
smtp-relay:  use pre existing secrets or add annotations

### DIFF
--- a/charts/smtp-relay/README.md
+++ b/charts/smtp-relay/README.md
@@ -43,6 +43,9 @@ An SMTP smarthost relay for Kubernetes
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| secret | object | See values.yaml | Configures secret settings for the chart. |
+| secret.annotations | object | `{}` | Additional annotations for the secret |
+| secret.create | bool | `true` | Create the secret containing the smtp-relay password |
 | service | object | See values.yaml | Configures service settings for the chart. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/smtp-relay/templates/secret.yaml
+++ b/charts/smtp-relay/templates/secret.yaml
@@ -1,8 +1,14 @@
+{{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "smtp-relay.fullname" . }}
   labels:
     {{- include "smtp-relay.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   smtp-relay-password: {{ .Values.smtp.password | b64enc }}
+{{- end }}

--- a/charts/smtp-relay/values.schema.json
+++ b/charts/smtp-relay/values.schema.json
@@ -257,6 +257,25 @@
       "title": "securityContext",
       "type": "object"
     },
+    "secret": {
+      "description": "Configures secret settings for the chart.",
+      "properties": {
+        "create": {
+          "default": "true",
+          "required": [],
+          "title": "create",
+          "type": "boolean"
+        },
+        "annotations": {
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "secret",
+      "type": "object"
+    },
     "service": {
       "description": "Configures service settings for the chart.",
       "properties": {

--- a/charts/smtp-relay/values.yaml
+++ b/charts/smtp-relay/values.yaml
@@ -69,6 +69,14 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Configures secret settings for the chart.
+# @default -- See values.yaml
+secret:
+  # -- Create the secret containing the smtp-relay password
+  create: true
+  # -- Additional annotations for the secret
+  annotations: {}
+
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
 service:


### PR DESCRIPTION
<!--
Thank you for contributing to djjudas21/charts.
Before you submit this pull request we'd like to make sure you are aware of best practices:

* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR introduces the possibility to add custom annotations to the smtp-relay secret and the ability to pre-create the secret before installing the helm chart.

As a devops engineer, I like to use the gitops concept and my customers use tools like ArgoCD. However, from the IT security perspective, it makes me feel queasy, thinking about having a custom values file in some git repository containing everything you need to use the upstream SMTP server to deliver tons of tasty SPAM(tm). Most of my customers feel the same and use various methods to limit exposure (vault, sealed secrets, etc). For those cases, it is very useful to pre-create the secret before installing smtp-relay and then just use those secrets without ArgoCD complaining about a deployment being "Out of Sync" because we modified the secret afterwards.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
