### PR TITLE
[LLDAP] Rootless images

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -45,4 +45,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update to LLDAP v0.6.2
+      description: Update to LLDAP v0.6.2 with rootless image by default

--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.1"
+appVersion: "v0.6.2"
 
 keywords:
   - rust
@@ -45,4 +45,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Fix bootstrap image tag
+      description: Update to LLDAP v0.6.2

--- a/charts/lldap/README.md
+++ b/charts/lldap/README.md
@@ -1,6 +1,6 @@
 # lldap
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
 
 Light LDAP implementation
 
@@ -38,9 +38,10 @@ Light LDAP implementation
 | externalPostgresql | object | `{"auth":{"database":"lldap","host":"","password":"","port":5432,"username":""},"enabled":false}` | - Enable and configure external postgresql database |
 | externalPostgresql.auth | object | `{"database":"lldap","host":"","password":"","port":5432,"username":""}` | Name of the secret key containing the database URI uriKey: |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| image.repository | string | `"lldap/lldap"` | image repository |
-| image.tag | string | chart.appVersion | image tag |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"lldap/lldap"` | Image repository |
+| image.tag | string | chart.appVersion | Image tag |
+| image.variant | string | `"-debian-rootless"` | Image variant. Leave blank for default image. |
 | imagePullSecrets | list | `[]` |  |
 | ingress | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | livenessProbe.httpGet.path | string | `"/"` |  |

--- a/charts/lldap/templates/bootstrap-job.yaml
+++ b/charts/lldap/templates/bootstrap-job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: bootstrap
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.variant }}"
           command:
             - ./bootstrap.sh
           env:

--- a/charts/lldap/templates/bootstrap-job.yaml
+++ b/charts/lldap/templates/bootstrap-job.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
+  ttlSecondsAfterFinished: 300
   template:
     spec:
       restartPolicy: OnFailure

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.variant }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: UID

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -263,23 +263,30 @@
       "properties": {
         "pullPolicy": {
           "default": "IfNotPresent",
-          "description": "image pull policy",
+          "description": "Image pull policy",
           "required": [],
           "title": "pullPolicy",
           "type": "string"
         },
         "repository": {
           "default": "lldap/lldap",
-          "description": "image repository",
+          "description": "Image repository",
           "required": [],
           "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
-          "description": "image tag",
+          "description": "Image tag",
           "required": [],
           "title": "tag",
+          "type": "string"
+        },
+        "variant": {
+          "default": "-debian-rootless",
+          "description": "Image variant. Leave blank for default image.",
+          "required": [],
+          "title": "variant",
           "type": "string"
         }
       },

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -5,13 +5,15 @@
 replicaCount: 1
 
 image:
-  # -- image repository
+  # -- Image repository
   repository: lldap/lldap
-  # -- image pull policy
+  # -- Image pull policy
   pullPolicy: IfNotPresent
-  # -- image tag
+  # -- Image tag
   # @default -- chart.appVersion
   tag: ""
+  # -- Image variant. Leave blank for default image.
+  variant: "-debian-rootless"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR provides a new variable `image.variant` which allows the user to specify a variant to be appended to the image tag. By default this is set to `-debian-rootless` to deploy a rootless image which should increase compatibility with OpenShift.

I have kept `tag` and `variant` as separate variables so the user can follow a train of rootless releases without having to override `tag` at each upgrade.

I also take this opportunity to upgrade LLDAP `v0.6.1` to `v0.6.2`.

This tests fine on RKE2.

#### Which issue this PR fixes

* fixes #172 

#### Special notes for your reviewer

Are you satisfied with this, @ClemaX?

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
