### PR TITLE
[alertmanager-ntfy] Add support for existing configmap

### DIFF
--- a/charts/alertmanager-ntfy/Chart.yaml
+++ b/charts/alertmanager-ntfy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/alertmanager-ntfy/templates/_helpers.tpl
+++ b/charts/alertmanager-ntfy/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the name of the ConfigMap to use
+*/}}
+{{- define "alertmanager-ntfy.configMapName" -}}
+{{- if .Values.configMap.existingConfigMap }}
+{{- .Values.configMap.existingConfigMap }}
+{{- else }}
+{{- printf "%s-config" (include "alertmanager-ntfy.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-ntfy/templates/config.yaml
+++ b/charts/alertmanager-ntfy/templates/config.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configMap.existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
 data:
   config.yml: |
 {{ toYaml .Values.config | indent 4 }}
+{{- end }}

--- a/charts/alertmanager-ntfy/templates/deployment.yaml
+++ b/charts/alertmanager-ntfy/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "alertmanager-ntfy.fullname" . }}-config
+          name: {{ include "alertmanager-ntfy.configMapName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alertmanager-ntfy/values.schema.json
+++ b/charts/alertmanager-ntfy/values.schema.json
@@ -196,6 +196,21 @@
       "title": "config",
       "type": "object"
     },
+    "configMap": {
+      "description": "ConfigMap configuration",
+      "properties": {
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap containing the alertmanager-ntfy configuration. When set, the chart will not create a ConfigMap and will use this instead. The ConfigMap must contain a key named 'config.yml'",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMap",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "required": [],

--- a/charts/alertmanager-ntfy/values.yaml
+++ b/charts/alertmanager-ntfy/values.yaml
@@ -101,6 +101,13 @@ tolerations: []
 
 affinity: {}
 
+# ConfigMap configuration
+configMap:
+  # -- Name of an existing ConfigMap containing the alertmanager-ntfy configuration.
+  # When set, the chart will not create a ConfigMap and will use this instead.
+  # The ConfigMap must contain a key named 'config.yml'
+  existingConfigMap: ""
+
 # -- Contains config.yml for alertmanager-ntfy
 # @default -- See https://github.com/alexbakker/alertmanager-ntfy
 config:


### PR DESCRIPTION
<!--
Thank you for contributing to djjudas21/charts.
Before you submit this pull request we'd like to make sure you are aware of best practices:

* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Adds support to reference an existing configmap for configuration rather than creating it as part of the helm deployment which plays better with gitops and allows forcing the pod to restart when the configmap is replaced.

#### Which issue this PR fixes
No issue raised

#### Special notes for your reviewer
Variables modelled from Bitnami charts
Should be fully backwards compatible
@djjudas21 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
