### PR TITLE
Add IPv6 support

### DIFF
--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.5
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -45,4 +45,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update to LLDAP v0.6.2 with rootless image by default
+      description: Add IPv6 support

--- a/charts/lldap/README.md
+++ b/charts/lldap/README.md
@@ -1,6 +1,6 @@
 # lldap
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
 
 Light LDAP implementation
 
@@ -50,10 +50,12 @@ Light LDAP implementation
 | lldap.extraVolumeMounts | list | `[]` |  |
 | lldap.extraVolumes | list | `[]` | - define extra volumes and mounts for the ldap |
 | lldap.gid | int | `1000` |  |
+| lldap.httpHost | string | `"0.0.0.0"` | HTTP API host. To enable IPv6 listening, change to `::` |
 | lldap.jwtSecret | string | `"REPLACE_WITH_RANDOM"` | Random secret for JWT signature. This secret should be random, and should be shared with application servers that need to consume the JWTs. Changing this secret will invalidate all user sessions and require them to re-login. You can generate it with (on linux): LC_ALL=C tr -dc 'A-Za-z0-9!#%&'\''()*+,-./:;<=>?@[\]^_{|}~' </dev/urandom | head -c 32; echo '' |
 | lldap.jwtSecretKey | string | `"jwtSecret"` | Name of the JWT signature key in the `.Values.lldap.secretName` Kubernetes secret. |
 | lldap.keySeed | string | `"REPLACE_WITH_RANDOM"` | Seed to generate the server private key. This can be any random string, the recommendation is that it's at least 12 characters long. |
 | lldap.keySeedKey | string | `"keySeed"` | Name of the key holding the private key seed in the `.Values.lldap.secretName` Kubernetes secret. |
+| lldap.ldapHost | string | `"0.0.0.0"` | LDAP host. To enable IPv6 listening, change to `::` |
 | lldap.ldapUserDN | string | `"admin"` | Admin username. For the LDAP interface, a value of "admin" here will create the LDAP user "cn=admin,ou=people,dc=example,dc=com" (with the base DN above). For the administration interface, this is the username. |
 | lldap.ldapUserPass | string | `"REPLACE_WITH_RANDOM"` | Admin password. Password for the admin account, both for the LDAP bind and for the administration interface. It is only used when initially creating the admin user. It should be minimum 8 characters long. Note: you can create another admin user for user administration, this is just the default one. |
 | lldap.ldapUserPassKey | string | `"ldapUserPass"` | Name of the LDAP admin password key in the `.Values.lldap.secretName` Kubernetes secret. |

--- a/charts/lldap/templates/deployment.yaml
+++ b/charts/lldap/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               value: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{- with (first .paths) }}{{ .path }}{{- end }}
             {{- end }}
             {{- end }}
+            - name: LLDAP_LDAP_HOST
+              value: "{{ .Values.lldap.ldapHost }}"
+            - name: LLDAP_HTTP_HOST
+              value: "{{ .Values.lldap.httpHost }}"
             - name: LLDAP_LDAP_PORT
               value: "{{ .Values.service.ldap.port }}"
             - name: LLDAP_HTTP_PORT

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -444,6 +444,13 @@
           "title": "gid",
           "type": "integer"
         },
+        "httpHost": {
+          "default": "0.0.0.0",
+          "description": "HTTP API host. To enable IPv6 listening, change to `::`",
+          "required": [],
+          "title": "httpHost",
+          "type": "string"
+        },
         "jwtSecret": {
           "default": "REPLACE_WITH_RANDOM",
           "description": "Random secret for JWT signature.\nThis secret should be random, and should be shared with application servers that need to\nconsume the JWTs. Changing this secret will invalidate all user sessions and require them\nto re-login. You can generate it with (on linux):\nLC_ALL=C tr -dc 'A-Za-z0-9!#%\u0026'\\''()*+,-./:;\u003c=\u003e?@[\\]^_{|}~' \u003c/dev/urandom | head -c 32; echo ''",
@@ -470,6 +477,13 @@
           "description": "Name of the key holding the private key seed in the `.Values.lldap.secretName` Kubernetes secret.",
           "required": [],
           "title": "keySeedKey",
+          "type": "string"
+        },
+        "ldapHost": {
+          "default": "0.0.0.0",
+          "description": "LDAP host. To enable IPv6 listening, change to `::`",
+          "required": [],
+          "title": "ldapHost",
           "type": "string"
         },
         "ldapUserDN": {

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -66,6 +66,12 @@ lldap:
   # -- Name of the key holding the private key seed in the `.Values.lldap.secretName` Kubernetes secret.
   keySeedKey: keySeed
 
+  # -- LDAP host. To enable IPv6 listening, change to `::`
+  ldapHost: 0.0.0.0
+
+  # -- HTTP API host. To enable IPv6 listening, change to `::`
+  httpHost: 0.0.0.0
+
   uid: 1000
   gid: 1000
   tz: "Etc/UTC"

--- a/charts/navidrome/README.md
+++ b/charts/navidrome/README.md
@@ -1,6 +1,6 @@
 # navidrome
 
-![Version: 6.7.4](https://img.shields.io/badge/Version-6.7.4-informational?style=flat-square) ![AppVersion: 0.57.0](https://img.shields.io/badge/AppVersion-0.57.0-informational?style=flat-square)
+![Version: 6.7.5](https://img.shields.io/badge/Version-6.7.5-informational?style=flat-square) ![AppVersion: 0.58.0](https://img.shields.io/badge/AppVersion-0.58.0-informational?style=flat-square)
 
 Navidrome is an open source web-based music collection server and streamer
 


### PR DESCRIPTION
Add IPv6 support to LLDAP by allowing the user to set `LLDAP_LDAP_HOST` and `LLDAP_HTTP_HOST`.

Fixes #180 