### PR TITLE
Add service annotation support

### DIFF
--- a/charts/alertmanager-ntfy/README.md
+++ b/charts/alertmanager-ntfy/README.md
@@ -1,6 +1,6 @@
 # alertmanager-ntfy
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 Service that forwards Prometheus Alertmanager notifications to ntfy.sh
 
@@ -35,6 +35,7 @@ named [wrenix/alertmanager-ntfy](https://codeberg.org/wrenix/helm-charts/src/bra
 | config.ntfy.auth.token | string | `"verysecureauthtoken"` | Token for alertmanager-ntfy to connect to ntfy |
 | config.ntfy.baseurl | string | `"https://ntfy.sh"` | URL for ntfy service, if not using ntfy.sh |
 | config.ntfy.notification.topic | string | `"alertmanager"` | ntfy topic. Can either be a hardcoded string or a gval expression that evaluates to a string |
+| configMap.existingConfigMap | string | `""` | Name of an existing ConfigMap containing the alertmanager-ntfy configuration. When set, the chart will not create a ConfigMap and will use this instead. The ConfigMap must contain a key named 'config.yml' |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/alexbakker/alertmanager-ntfy"` |  |

--- a/charts/alertmanager-ntfy/values.schema.json
+++ b/charts/alertmanager-ntfy/values.schema.json
@@ -201,7 +201,7 @@
       "properties": {
         "existingConfigMap": {
           "default": "",
-          "description": "Name of an existing ConfigMap containing the alertmanager-ntfy configuration. When set, the chart will not create a ConfigMap and will use this instead. The ConfigMap must contain a key named 'config.yml'",
+          "description": "Name of an existing ConfigMap containing the alertmanager-ntfy configuration.\nWhen set, the chart will not create a ConfigMap and will use this instead.\nThe ConfigMap must contain a key named 'config.yml'",
           "required": [],
           "title": "existingConfigMap",
           "type": "string"

--- a/charts/lldap/Chart.yaml
+++ b/charts/lldap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -45,4 +45,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Add IPv6 support
+      description: Add service annotation support

--- a/charts/lldap/README.md
+++ b/charts/lldap/README.md
@@ -1,6 +1,6 @@
 # lldap
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
 
 Light LDAP implementation
 

--- a/charts/lldap/templates/service.yaml
+++ b/charts/lldap/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "lldap.fullname" . }}-http
   labels:
     {{- include "lldap.labels" . | nindent 4 }}
+{{- if .Values.service.http.annotations }}
+  annotations:
+{{ toYaml .Values.service.http.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.http.type }}
   ports:
@@ -20,6 +24,10 @@ metadata:
   name: {{ include "lldap.fullname" . }}-ldap
   labels:
     {{- include "lldap.labels" . | nindent 4 }}
+{{- if .Values.service.ldap.annotations }}
+  annotations:
+{{ toYaml .Values.service.ldap.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.ldap.type }}
   ports:

--- a/charts/lldap/values.schema.json
+++ b/charts/lldap/values.schema.json
@@ -897,6 +897,11 @@
       "properties": {
         "http": {
           "properties": {
+            "annotations": {
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
             "port": {
               "default": 17170,
               "required": [],
@@ -916,6 +921,11 @@
         },
         "ldap": {
           "properties": {
+            "annotations": {
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
             "port": {
               "default": 3890,
               "required": [],

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -157,9 +157,11 @@ service:
   http:
     type: ClusterIP
     port: 17170
+    annotations: {}
   ldap:
     type: ClusterIP
     port: 3890
+    annotations: {}
   ldaps:
     type: ClusterIP
     port: 6360


### PR DESCRIPTION
Add support for setting annotations on services. This allows additional configuration of MetalLB load balancers, for example.

Fixes #176